### PR TITLE
Code of conduct website changes

### DIFF
--- a/_includes/shared/header.html
+++ b/_includes/shared/header.html
@@ -22,6 +22,7 @@
                 <li><a href="/who-we-are"><i class="fa fa-users"></i> Who We Are</a></li>
                 <li><a href="/what-we-do"><i class="fa fa-wrench"></i> What We Do</a></li>
                 <li><a href="/projects"><i class="fa fa-cogs"></i> Our Projects</a></li>
+                <li><a href="/projects"><i class="fa fa-file-text"></i> Code of Conduct</a></li>
               </ul>
             </li>
 

--- a/codeofconduct.md
+++ b/codeofconduct.md
@@ -1,5 +1,5 @@
 ---
-title: codeofconduct
+title: Code of Conduct
 author: Code for Sacramento
 layout: codeofconduct
 permalink: /codeofconduct/


### PR DESCRIPTION
Here are a few ideas for how to display the code of conduct. I included a link in the About section of the nav bar, but it's just a suggestion; don't feel the need to include it in your pull request.

I think Brianda would have a good idea of what other brigades do since I know they have bookmarked a lot of the brigade websites to look at as an example. I found [Code for DC's website](https://codefordc.org/) interesting how they placed Code of Conduct as prominently in the nav bar.